### PR TITLE
Fix link-rewriting and improve image-handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+__pycache__
 *.epub
 cookie

--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ aiolimiter = "*"
 bs4 = "*"
 ebooklib = "*"
 lxml = "*"
+pillow = "*"
 tqdm = "*"
 tzdata = "*"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6e7b70b67fda024c0a449daa7a8687f2fecc5bf3cf21f08d856d3be110c0759a"
+            "sha256": "ae3f7fe667c430f1f59517cd5cc98ddebbdcd593dc9ab9b3c5b136b41519ca40"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -146,7 +146,7 @@
                 "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
                 "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"
             ],
-            "markers": "python_version >= '3.5'",
+            "markers": "python_full_version >= '3.5.0'",
             "version": "==2.0.12"
         },
         "colorama": {
@@ -234,7 +234,7 @@
                 "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
                 "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
             ],
-            "markers": "python_version >= '3.5'",
+            "markers": "python_full_version >= '3.5.0'",
             "version": "==3.3"
         },
         "lxml": {
@@ -370,6 +370,50 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==6.0.2"
+        },
+        "pillow": {
+            "hashes": [
+                "sha256:088df396b047477dd1bbc7de6e22f58400dae2f21310d9e2ec2933b2ef7dfa4f",
+                "sha256:09e67ef6e430f90caa093528bd758b0616f8165e57ed8d8ce014ae32df6a831d",
+                "sha256:0b4d5ad2cd3a1f0d1df882d926b37dbb2ab6c823ae21d041b46910c8f8cd844b",
+                "sha256:0b525a356680022b0af53385944026d3486fc8c013638cf9900eb87c866afb4c",
+                "sha256:1d4331aeb12f6b3791911a6da82de72257a99ad99726ed6b63f481c0184b6fb9",
+                "sha256:20d514c989fa28e73a5adbddd7a171afa5824710d0ab06d4e1234195d2a2e546",
+                "sha256:2b291cab8a888658d72b575a03e340509b6b050b62db1f5539dd5cd18fd50578",
+                "sha256:3f6c1716c473ebd1649663bf3b42702d0d53e27af8b64642be0dd3598c761fb1",
+                "sha256:42dfefbef90eb67c10c45a73a9bc1599d4dac920f7dfcbf4ec6b80cb620757fe",
+                "sha256:488f3383cf5159907d48d32957ac6f9ea85ccdcc296c14eca1a4e396ecc32098",
+                "sha256:4d45dbe4b21a9679c3e8b3f7f4f42a45a7d3ddff8a4a16109dff0e1da30a35b2",
+                "sha256:53c27bd452e0f1bc4bfed07ceb235663a1df7c74df08e37fd6b03eb89454946a",
+                "sha256:55e74faf8359ddda43fee01bffbc5bd99d96ea508d8a08c527099e84eb708f45",
+                "sha256:59789a7d06c742e9d13b883d5e3569188c16acb02eeed2510fd3bfdbc1bd1530",
+                "sha256:5b650dbbc0969a4e226d98a0b440c2f07a850896aed9266b6fedc0f7e7834108",
+                "sha256:66daa16952d5bf0c9d5389c5e9df562922a59bd16d77e2a276e575d32e38afd1",
+                "sha256:6e760cf01259a1c0a50f3c845f9cad1af30577fd8b670339b1659c6d0e7a41dd",
+                "sha256:7502539939b53d7565f3d11d87c78e7ec900d3c72945d4ee0e2f250d598309a0",
+                "sha256:769a7f131a2f43752455cc72f9f7a093c3ff3856bf976c5fb53a59d0ccc704f6",
+                "sha256:7c150dbbb4a94ea4825d1e5f2c5501af7141ea95825fadd7829f9b11c97aaf6c",
+                "sha256:8844217cdf66eabe39567118f229e275f0727e9195635a15e0e4b9227458daaf",
+                "sha256:8a66fe50386162df2da701b3722781cbe90ce043e7d53c1fd6bd801bca6b48d4",
+                "sha256:9370d6744d379f2de5d7fa95cdbd3a4d92f0b0ef29609b4b1687f16bc197063d",
+                "sha256:937a54e5694684f74dcbf6e24cc453bfc5b33940216ddd8f4cd8f0f79167f765",
+                "sha256:9c857532c719fb30fafabd2371ce9b7031812ff3889d75273827633bca0c4602",
+                "sha256:a4165205a13b16a29e1ac57efeee6be2dfd5b5408122d59ef2145bc3239fa340",
+                "sha256:b3fe2ff1e1715d4475d7e2c3e8dabd7c025f4410f79513b4ff2de3d51ce0fa9c",
+                "sha256:b6617221ff08fbd3b7a811950b5c3f9367f6e941b86259843eab77c8e3d2b56b",
+                "sha256:b761727ed7d593e49671d1827044b942dd2f4caae6e51bab144d4accf8244a84",
+                "sha256:baf3be0b9446a4083cc0c5bb9f9c964034be5374b5bc09757be89f5d2fa247b8",
+                "sha256:c17770a62a71718a74b7548098a74cd6880be16bcfff5f937f900ead90ca8e92",
+                "sha256:c67db410508b9de9c4694c57ed754b65a460e4812126e87f5052ecf23a011a54",
+                "sha256:d78ca526a559fb84faaaf84da2dd4addef5edb109db8b81677c0bb1aad342601",
+                "sha256:e9ed59d1b6ee837f4515b9584f3d26cf0388b742a11ecdae0d9237a94505d03a",
+                "sha256:f054b020c4d7e9786ae0404278ea318768eb123403b18453e28e47cdb7a0a4bf",
+                "sha256:f372d0f08eff1475ef426344efe42493f71f377ec52237bf153c5713de987251",
+                "sha256:f3f6a6034140e9e17e9abc175fc7a266a6e63652028e157750bd98e804a8ed9a",
+                "sha256:ffde4c6fabb52891d81606411cbfaf77756e3b561b566efd270b3ed3791fde4e"
+            ],
+            "index": "pypi",
+            "version": "==9.1.1"
         },
         "six": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Downloads glowfic! Invoke it like so:
 ```
 If you get errors, make sure you've got the dependencies installed:
 ```
-pip3 install aiohttp aiolimiter bs4 ebooklib lxml tqdm tzdata
+pip3 install aiohttp aiolimiter bs4 ebooklib lxml pillow tqdm tzdata
 ```
 ...or use a pipenv virtualenv for an extra guarantee of a clean and functional install:
 ```

--- a/glowfic-dl.py
+++ b/glowfic-dl.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python3
 
-# Minimal wrapper around main.py
-import src.main
+import asyncio
+import platform
+
+from src.main import main
+
+# Lightweight wrapper around main.py
+if platform.system() == "Windows":
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+asyncio.run(main())

--- a/src/main.py
+++ b/src/main.py
@@ -16,9 +16,6 @@ from .render import *
 #   post was linked to from reply #114 of Mad investor chaos". <a>Return
 #   there</a>.
 # * Less bad covers
-# * When taking in images of format other than PNG/JPEG/GIF/SVG, convert them
-#   to one of those formats, for EPUB specification compliance
-# * Fix whatever's wrong with link-rewriting right now
 
 
 ################
@@ -76,16 +73,15 @@ async def main():
             image_map = ImageMap()
             authors = OrderedDict()
 
-            print("Downloading chapter texts")
-            chapters = await tqdm.gather(
-                *[
-                    download_chapter(
-                        slow_session, limiter, stamped_url, image_map, authors
-                    )
-                    for (i, stamped_url) in enumerate(spec.stamped_urls)
-                ]
+            downloaded_chapters = await download_chapters(
+                slow_session,
+                limiter,
+                fast_session,
+                spec.stamped_urls,
+                image_map,
+                authors,
             )
-            chapters = list(compile_chapters(chapters))
+            chapters = list(compile_chapters(downloaded_chapters))
             for chapter in chapters:
                 for section in chapter:
                     book.add_item(section)
@@ -99,8 +95,7 @@ async def main():
             )
             book.add_item(style)
 
-            print("Downloading images")
-            images = await download_images(fast_session, image_map)
+            images = get_images_as_epub_items(image_map)
 
             for image in images:
                 book.add_item(image)

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,6 @@
 import argparse
-import asyncio
 from collections import OrderedDict
 import os
-import platform
 
 import aiohttp
 import aiolimiter
@@ -122,8 +120,3 @@ async def main():
             out_path = "%s.epub" % spec.title
             print("Saving book to %s" % out_path)
             epub.write_epub(out_path, book, {})
-
-
-if platform.system() == "Windows":
-    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-asyncio.run(main())

--- a/src/main.py
+++ b/src/main.py
@@ -18,7 +18,6 @@ from .render import *
 # * Less bad covers
 # * When taking in images of format other than PNG/JPEG/GIF/SVG, convert them
 #   to one of those formats, for EPUB specification compliance
-# * Download inline images too, not just icons
 # * Fix whatever's wrong with link-rewriting right now
 
 

--- a/src/render.py
+++ b/src/render.py
@@ -86,7 +86,9 @@ class MappedImage:
             self.is_null = True
         processed = process_image_for_epub3(file)
         if processed is None:
-            print("Downloaded %s, but it wasn't an image" % url)
+            print(
+                "Downloaded %s, but it wasn't an image of EPUB3-compatible format" % url
+            )
             self.is_null = True
         else:
             self.file, self.media_type, self.ext = processed
@@ -239,7 +241,7 @@ def render_post(post: Tag, image_map: ImageMap) -> RenderedPost:
     for inline_img in content.find_all("img"):
         mapped_image = image_map.get_image_name(inline_img["src"])
         if mapped_image is not None:
-            inline_img["src"] = "../%s" % image_map.get_image_name(inline_img["src"])
+            inline_img["src"] = "../%s" % mapped_image
 
     post_html = BeautifulSoup('<div class="post"></div>', "html.parser")
     post_div = post_html.find("div")

--- a/src/render.py
+++ b/src/render.py
@@ -242,6 +242,8 @@ def render_post(post: Tag, image_map: ImageMap) -> RenderedPost:
         mapped_image = image_map.get_image_name(inline_img["src"])
         if mapped_image is not None:
             inline_img["src"] = "../%s" % mapped_image
+        else:
+            inline_img["src"] = "data:,"
 
     post_html = BeautifulSoup('<div class="post"></div>', "html.parser")
     post_div = post_html.find("div")


### PR DESCRIPTION
Functionality:
- Cover more cases with link-rewriting (absolute, rather than just relative, links)
- Pull inline images into the book too, rather than just icons, and rewrite `img` tags' `src` attributes accordingly
- Ensure that all images are of valid types for EPUB 3 to display without fallback (JPEG, PNG, GIF, SVG), converting when possible and omitting otherwise
    - As a side effect of this, previous buggy path-generation for images without extensions in their URLs has now been fixed, since extensions are now generated based on format rather than based on extensions-as-found-in-their-URLs

Code cleanup:
- Pull all auto-run code from `main.py` to `glowfic-dl.py`, thus allowing `main.py` to be accessed as a library without side effects (e.g. for unit testing)

Overall order of operations has now been changed somewhat: all posts are downloaded, and then all images downloaded, and then all rendering and compilation performed, in that order rather than the previous more-interspersed order. This was required in order to get the image-format-conversion working properly: all posts needed to be downloaded in order to enable all images to be downloaded, all images needed to be downloaded and format-converted in order to know whether to include them (and, if so, what extension to give them) within the rendered posts.