### PR TITLE
Thread title pages, split behavior control, and miscellanea

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,4 @@
 import argparse
-from collections import OrderedDict
 import os
 
 import aiohttp
@@ -22,6 +21,7 @@ from .render import (
 #   post was linked to from reply #114 of Mad investor chaos". <a>Return
 #   there</a>.
 # * Less bad covers
+# * Increase configurability of title page content
 
 
 ################
@@ -84,7 +84,7 @@ async def main():
 
             book = epub.EpubBook()
             image_map = ImageMap()
-            authors = OrderedDict()
+            authors = set()
 
             downloaded_chapters = await download_chapters(
                 slow_session,
@@ -114,7 +114,7 @@ async def main():
             for image in images:
                 book.add_item(image)
 
-            for author in authors.keys():
+            for author in sorted(authors):
                 book.add_author(author)
 
             book.toc = [chapter[0] for chapter in chapters]

--- a/src/main.py
+++ b/src/main.py
@@ -5,9 +5,15 @@ import os
 import aiohttp
 import aiolimiter
 from ebooklib import epub
-from tqdm.asyncio import tqdm
 
-from .render import *
+from .render import (
+    stylesheet,
+    ImageMap,
+    compile_chapters,
+    download_chapters,
+    get_images_as_epub_items,
+    get_post_urls_and_title,
+)
 
 # TODO:
 # * Better kobo handling
@@ -36,7 +42,14 @@ def get_args() -> argparse.Namespace:
         description="Download glowfic from the Glowfic Constellation."
     )
 
-    parser.add_argument("url", help="glowfic post, section, or board URL")
+    parser.add_argument("url", help="glowfic thread, section, or board URL")
+    parser.add_argument(
+        "--split",
+        "-s",
+        choices=["none", "if_large", "every_post"],
+        default="if_large",
+        help="how often (if at all) to split books' internal representations of threads into multiple files. 'none' means no splits occur; 'if_large' splits after every 200kB of internal file-size; 'every_post' splits after each post irrespective of size. Default: if_large",
+    )
 
     return parser.parse_args()
 
@@ -80,6 +93,7 @@ async def main():
                 spec.stamped_urls,
                 image_map,
                 authors,
+                args.split,
             )
             chapters = list(compile_chapters(downloaded_chapters))
             for chapter in chapters:

--- a/src/render.py
+++ b/src/render.py
@@ -52,7 +52,12 @@ div.post {
     page-break-inside: avoid;
 }
 .title, .authors {
-    text-align:center;
+    text-align: center;
+}
+.extlink::after {
+    content: "\u29c9";
+    vertical-align: super;
+	font-size: 0.7rem;
 }
 """.lstrip()
 
@@ -377,7 +382,7 @@ def compile_chapters(
             for permalink in section.link_targets:
                 anchor_sections[permalink] = file_name
 
-    # Replace external links with internal links where possible
+    # Replace external links with internal links where possible, and tag those which remain
     for (i, (title, sections)) in enumerate(chapters):
         for (j, section) in enumerate(sections):
             for a in section.html.find_all("a"):
@@ -391,12 +396,13 @@ def compile_chapters(
                     abs = ABSOLUTE_REPLY_RE.match(raw_url)
                     if abs is not None and abs.group("relative") in anchor_sections:
                         a["href"] = anchor_sections[abs.group("relative")]
-                    elif (
-                        url.netloc == ""
-                    ):  # Relative link to something not included here
+                    elif url.netloc == "":  # Relative external link
                         a["href"] = url._replace(
                             scheme="https", netloc="glowfic.com"
                         ).geturl()
+                        a["class"] = a.get("class", []) + ["extlink"]
+                    else:  # Absolute external link
+                        a["class"] = a.get("class", []) + ["extlink"]
 
     # Yield one list of EpubHTML objects per chapter
     for (i, (title, sections)) in enumerate(chapters):


### PR DESCRIPTION
Changes:
- Add switch `--split` to control thread-splitting behavior, with three options: `none` to have every thread as one file, `if_large` for current behavior (and as the continued default), `every_post` to split after every post in each thread.
- Add title page to each thread, listing title and authors. (In the future it may be worth adding settings for inclusion of additional metadata; for the moment, though, this seems like enough to get started with, resolving the immediate problem where there's no indication of thread titles anywhere in the book-flow except the table of contents.)
- List authors alphabetically rather than in order of first posting, as is done on the Constellation itself.
- Remove `posts` div, since it is in practice never used.
- Add superscript `⧉` icon to the ends of external links (via CSS `::after` selector), to make the distinction between internal and external links visible to readers.

Next up will be adding title pages for continuities and sections, and nested tables of contents. But that looks like it's going to involve some pretty radical revisions to the code-flow, so it seems worth submitting the PR in its current state as an intermediate step.