### PR TITLE
Fixed an error when some special characters appear in the title.

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -124,7 +124,12 @@ async def main():
             book.spine = ["nav"] + [
                 section for chapter in chapters for section in chapter
             ]
-
+            
+            # Prevent failure on Windows when a disallowed character (any of \/:*?"<>|) appears in the title
+            allowed_chars = " 1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+            getVals = list(filter(lambda x: x in allowed_chars, spec.title))
+            spec.title = "".join(getVals)
+            
             out_path = "%s.epub" % spec.title
             print("Saving book to %s" % out_path)
             epub.write_epub(out_path, book, {})


### PR DESCRIPTION
Certain characters cannot be included in a file name in Windows (any of \/:*?"<>|). This change strips out all characters from the title except numbers, letters, and spaces, ensuring the .epub file can be created. 