### PR TITLE
Select tags by posted date

### DIFF
--- a/glowfic_dl/book_structure.py
+++ b/glowfic_dl/book_structure.py
@@ -89,10 +89,10 @@ class Thread:
             return str(self.id)
         start = "start"
         if self.start_date is not None:
-            start = self.start_date.strftime("%Y%m%dT%H%M%S")
+            start = self.start_date.isoformat()
         end = "end"
         if self.end_date is not None:
-            end = self.end_date.strftime("%Y%m%dT%H%M%S")
+            end = self.end_date.isoformat()
         return f"{self.id}-{start}-{end}"
 
     def add_soup(self, soup: BeautifulSoup):
@@ -104,14 +104,10 @@ class Thread:
     def add_compiled_sections(self, compiled_sections: list[EpubHtml]):
         self.compiled_sections = compiled_sections
 
-    def set_start_date(self, date: datetime | str | None):
-        if isinstance(date, str):
-            date = datetime.fromisoformat(date).astimezone()
+    def set_start_date(self, date: datetime | None):
         self.start_date = date
 
-    def set_end_date(self, date: datetime | str | None):
-        if isinstance(date, str):
-            date = datetime.fromisoformat(date).astimezone()
+    def set_end_date(self, date: datetime | None):
         self.end_date = date
 
     def section_name(self, section_ix: int) -> str:
@@ -148,16 +144,20 @@ class Thread:
 
     def set_threads_date_range(
         self,
-        start_date: datetime | str | None,
-        end_date: datetime | str | None,
+        start_date: datetime | None,
+        end_date: datetime | None,
     ):
-        # if a lone thread is empty we'll just output the nothing normally
+        # set these dates for the thread
         self.set_start_date(start_date)
         self.set_end_date(end_date)
+
 
 def last_modified(book: EpubBook) -> datetime:
     for (content, attrs) in book.get_metadata("OPF", "meta"):
         if attrs.get("property") == "dcterms:modified":
+            # this time should be in UTC, hence it ending with a Z 
+            # however ebooklib mistakenly outputs it in local time
+            # so we will parse it as local time
             modified = datetime.fromisoformat(content.strip("Z"))
             return modified.astimezone()
     raise Exception("Couldn't find dcterms:modified")
@@ -193,9 +193,11 @@ class Section:
 
     def set_threads_date_range(
         self,
-        start_date: datetime | str | None,
-        end_date: datetime | str | None,
+        start_date: datetime | None,
+        end_date: datetime | None,
     ):
+        # set these dates for all the section's threads
+        # and remove empty threads
         for thread in self.threads:
             thread.set_start_date(start_date)
             thread.set_end_date(end_date)
@@ -230,9 +232,11 @@ class Continuity:
 
     def set_threads_date_range(
         self,
-        start_date: datetime | str | None,
-        end_date: datetime | str | None
+        start_date: datetime | None,
+        end_date: datetime | None
     ):
+        # set these dates for all the continuity's threads
+        # and remove empty threads and sections
         for section in self.sections:
             section.set_threads_date_range(start_date, end_date)
         if self.sectionless_threads is not None:

--- a/glowfic_dl/book_structure.py
+++ b/glowfic_dl/book_structure.py
@@ -85,6 +85,17 @@ class Thread:
             return True
         return False
 
+    def filename_prefix(self) -> str:
+        if self.start_date is None and self.end_date is None:
+            return str(self.id)
+        start = "start"
+        if self.start_date is not None:
+            start = self.start_date.strftime("%Y%m%dT%H%M%S")
+        end = "end"
+        if self.end_date is not None:
+            end = self.end_date.strftime("%Y%m%dT%H%M%S")
+        return f"{self.id}-{start}-{end}"
+
     def add_soup(self, soup: BeautifulSoup):
         self.soup = soup
 
@@ -109,24 +120,22 @@ class Thread:
         assert sections is not None
         section_digits = len(str(len(sections) - 1))
         return make_filename_valid_for_epub3(
-            "%i-%.*i.xhtml"
+            "%s-%.*i.xhtml"
             % (
-                self.id,
+                self.filename_prefix(),
                 section_digits,
                 section_ix,
             )
         )
 
     def load_compiled_sections_from_old_book(self, old_book: EpubBook):
-        if self.start_date is not None or self.end_date is not None:
-            return  # maybe raise error here?
         old_version_ts = last_modified(old_book)
-        if old_version_ts < self.updated_at:
+        all_done = self.end_date is not None and self.end_date < old_version_ts
+        if not all_done and old_version_ts < self.updated_at:
             return
         compiled_sections = []
         for item in old_book.get_items():
-            item.id = None
-            if item.get_name().startswith(f"Text/{self.id}"):
+            if item.get_name().startswith(f"Text/{self.filename_prefix()}"):
                 # Unclear why these are lost
                 item.title = self.title
                 item.add_meta(name="glowfic-post-id", content=str(self.id))

--- a/glowfic_dl/book_structure.py
+++ b/glowfic_dl/book_structure.py
@@ -86,10 +86,10 @@ class Thread:
             return str(self.id)
         start = "start"
         if self.start_date is not None:
-            start = self.start_date.isoformat()
+            start = self.start_date.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
         end = "end"
         if self.end_date is not None:
-            end = self.end_date.isoformat()
+            end = self.end_date.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
         return f"{self.id}-{start}-{end}"
 
     def add_soup(self, soup: BeautifulSoup):

--- a/glowfic_dl/book_structure.py
+++ b/glowfic_dl/book_structure.py
@@ -150,7 +150,8 @@ class Thread:
 def last_modified(book: EpubBook) -> datetime:
     for (content, attrs) in book.get_metadata("OPF", "meta"):
         if attrs.get("property") == "dcterms:modified":
-            return datetime.fromisoformat(content.strip("Z"))
+            modified = datetime.fromisoformat(content.strip("Z"))
+            return modified.astimezone()
     raise Exception("Couldn't find dcterms:modified")
 
 

--- a/glowfic_dl/book_structure.py
+++ b/glowfic_dl/book_structure.py
@@ -58,10 +58,10 @@ class Thread:
             post_json["created_at"].strip("Z")
         )
         self.created_at = self.created_at.replace(tzinfo=timezone.utc)
-        self.updated_at: datetime = datetime.fromisoformat(
+        self.tagged_at: datetime = datetime.fromisoformat(
             post_json["tagged_at"].strip("Z")
         )
-        self.updated_at = self.updated_at.replace(tzinfo=timezone.utc)
+        self.tagged_at = self.tagged_at.replace(tzinfo=timezone.utc)
         self.description: str = post_json.get("description")
         self.authors = [author["username"] for author in post_json["authors"]]
 
@@ -81,7 +81,7 @@ class Thread:
     def is_empty(self) -> bool:
         if self.end_date is not None and self.end_date < self.created_at:
             return True
-        if self.start_date is not None and self.start_date > self.updated_at:
+        if self.start_date is not None and self.start_date > self.tagged_at:
             return True
         return False
 
@@ -131,7 +131,7 @@ class Thread:
     def load_compiled_sections_from_old_book(self, old_book: EpubBook):
         old_version_ts = last_modified(old_book)
         all_done = self.end_date is not None and self.end_date < old_version_ts
-        if not all_done and old_version_ts < self.updated_at:
+        if not all_done and old_version_ts < self.tagged_at:
             return
         compiled_sections = []
         for item in old_book.get_items():

--- a/glowfic_dl/book_structure.py
+++ b/glowfic_dl/book_structure.py
@@ -58,10 +58,10 @@ class Thread:
             post_json["created_at"].strip("Z")
         )
         self.created_at = self.created_at.replace(tzinfo=timezone.utc)
-        self.tagged_at: datetime = datetime.fromisoformat(
+        self.updated_at: datetime = datetime.fromisoformat(
             post_json["tagged_at"].strip("Z")
         )
-        self.tagged_at = self.tagged_at.replace(tzinfo=timezone.utc)
+        self.updated_at = self.updated_at.replace(tzinfo=timezone.utc)
         self.description: str = post_json.get("description")
         self.authors = [author["username"] for author in post_json["authors"]]
 
@@ -81,7 +81,7 @@ class Thread:
     def is_empty(self) -> bool:
         if self.end_date is not None and self.end_date < self.created_at:
             return True
-        if self.start_date is not None and self.start_date > self.tagged_at:
+        if self.start_date is not None and self.start_date > self.updated_at:
             return True
         return False
 
@@ -131,7 +131,7 @@ class Thread:
     def load_compiled_sections_from_old_book(self, old_book: EpubBook):
         old_version_ts = last_modified(old_book)
         all_done = self.end_date is not None and self.end_date < old_version_ts
-        if not all_done and old_version_ts < self.tagged_at:
+        if not all_done and old_version_ts < self.updated_at:
             return
         compiled_sections = []
         for item in old_book.get_items():

--- a/glowfic_dl/book_structure.py
+++ b/glowfic_dl/book_structure.py
@@ -68,6 +68,9 @@ class Thread:
         self.start_date: datetime | None = None
         self.end_date: datetime | None = None
 
+        # May become True when adding start or end dates or in render_threads
+        self.is_empty: bool = False
+
         # Filled in by download_threads
         self.soup: BeautifulSoup | None = None
         # Filled in by render_threads
@@ -76,13 +79,6 @@ class Thread:
         self.compiled_sections: list[EpubHtml] | None = None
 
         self.threads: list[Thread] = [self]
-
-    def is_empty(self) -> bool:
-        if self.end_date is not None and self.end_date < self.created_at:
-            return True
-        if self.start_date is not None and self.start_date > self.updated_at:
-            return True
-        return False
 
     def filename_prefix(self) -> str:
         if self.start_date is None and self.end_date is None:
@@ -104,10 +100,17 @@ class Thread:
     def add_compiled_sections(self, compiled_sections: list[EpubHtml]):
         self.compiled_sections = compiled_sections
 
+    def mark_as_empty(self):
+        self.is_empty = True
+
     def set_start_date(self, date: datetime | None):
+        if date is not None and date > self.updated_at:
+            self.mark_as_empty()
         self.start_date = date
 
     def set_end_date(self, date: datetime | None):
+        if date is not None and date < self.created_at:
+            self.mark_as_empty()
         self.end_date = date
 
     def section_name(self, section_ix: int) -> str:
@@ -122,6 +125,9 @@ class Thread:
                 section_ix,
             )
         )
+
+    def remove_empty_threads(self):
+        return  # a single empty thread is left as-is
 
     def load_compiled_sections_from_old_book(self, old_book: EpubBook):
         old_version_ts = last_modified(old_book)
@@ -187,6 +193,9 @@ class Section:
     def add_title_page(self, title_page: EpubHtml):
         self.title_page = title_page
 
+    def remove_empty_threads(self):
+        self.threads = [thread for thread in self.threads if not thread.is_empty]
+
     def load_compiled_sections_from_old_book(self, old_book: EpubBook):
         for thread in self.threads:
             thread.load_compiled_sections_from_old_book(old_book)
@@ -201,7 +210,7 @@ class Section:
         for thread in self.threads:
             thread.set_start_date(start_date)
             thread.set_end_date(end_date)
-        self.threads = [thread for thread in self.threads if not thread.is_empty()]
+        self.remove_empty_threads()
 
 
 class Continuity:
@@ -226,6 +235,16 @@ class Continuity:
     def add_title_page(self, title_page: HtmlSection):
         self.title_page = title_page
 
+    def remove_empty_threads(self):
+        for section in self.sections:
+            section.remove_empty_threads()
+        self.sections = [section for section in self.sections if section.threads]
+        if self.sectionless_threads is not None:
+            self.sectionless_threads.remove_empty_threads()
+            if not self.sectionless_threads.threads:
+                self.sectionless_threads = None
+        self.threads = list(chain(*[section.threads for section in self.sections]))
+
     def load_compiled_sections_from_old_book(self, old_book: EpubBook):
         for thread in self.threads:
             thread.load_compiled_sections_from_old_book(old_book)
@@ -241,7 +260,4 @@ class Continuity:
             section.set_threads_date_range(start_date, end_date)
         if self.sectionless_threads is not None:
             self.sectionless_threads.set_threads_date_range(start_date, end_date)
-        self.sections = [section for section in self.sections if section.threads]
-        if self.sectionless_threads is not None and not self.sectionless_threads.threads:
-            self.sectionless_threads = None
-        self.threads = [thread for thread in self.threads if not thread.is_empty()]
+        self.remove_empty_threads()

--- a/glowfic_dl/book_structure.py
+++ b/glowfic_dl/book_structure.py
@@ -22,7 +22,6 @@ output_template = """
 </html>
 """.lstrip()
 
-
 #################
 ##   Classes   ##
 #################
@@ -57,8 +56,7 @@ class Thread:
         self.url: str = "https://glowfic.com/posts/%d" % post_json["id"]
         self.created_at: datetime = datetime.fromisoformat(
             post_json["created_at"].strip("Z")
-        )
-        self.created_at = self.created_at.replace(tzinfo=timezone.utc)
+        ).replace(tzinfo=timezone.utc)
         self.updated_at: datetime = datetime.fromisoformat(
             post_json["tagged_at"].strip("Z")
         ).replace(tzinfo=timezone.utc)

--- a/glowfic_dl/book_structure.py
+++ b/glowfic_dl/book_structure.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from itertools import chain
 from typing import Optional
 from typing_extensions import Self
@@ -54,11 +54,20 @@ class Thread:
         self.id: int = post_json["id"]
         self.title: str = post_json["subject"]
         self.url: str = "https://glowfic.com/posts/%d" % post_json["id"]
+        self.created_at: datetime = datetime.fromisoformat(
+            post_json["created_at"].strip("Z")
+        )
+        self.created_at = self.created_at.replace(tzinfo=timezone.utc)
         self.updated_at: datetime = datetime.fromisoformat(
             post_json["tagged_at"].strip("Z")
         )
+        self.updated_at = self.updated_at.replace(tzinfo=timezone.utc)
         self.description: str = post_json.get("description")
         self.authors = [author["username"] for author in post_json["authors"]]
+
+        # Filled in by the set_threads_date_range methods, called in download_ebook 
+        self.start_date: datetime | None = None
+        self.end_date: datetime | None = None
 
         # Filled in by download_threads
         self.soup: BeautifulSoup | None = None
@@ -69,6 +78,13 @@ class Thread:
 
         self.threads: list[Thread] = [self]
 
+    def is_empty(self) -> bool:
+        if self.end_date is not None and self.end_date < self.created_at:
+            return True
+        if self.start_date is not None and self.start_date > self.updated_at:
+            return True
+        return False
+
     def add_soup(self, soup: BeautifulSoup):
         self.soup = soup
 
@@ -77,6 +93,16 @@ class Thread:
 
     def add_compiled_sections(self, compiled_sections: list[EpubHtml]):
         self.compiled_sections = compiled_sections
+
+    def set_start_date(self, date: datetime | str | None):
+        if isinstance(date, str):
+            date = datetime.fromisoformat(date).astimezone()
+        self.start_date = date
+
+    def set_end_date(self, date: datetime | str | None):
+        if isinstance(date, str):
+            date = datetime.fromisoformat(date).astimezone()
+        self.end_date = date
 
     def section_name(self, section_ix: int) -> str:
         sections = self.compiled_sections or self.rendered_sections
@@ -92,6 +118,8 @@ class Thread:
         )
 
     def load_compiled_sections_from_old_book(self, old_book: EpubBook):
+        if self.start_date is not None or self.end_date is not None:
+            return  # maybe raise error here?
         old_version_ts = last_modified(old_book)
         if old_version_ts < self.updated_at:
             return
@@ -110,6 +138,14 @@ class Thread:
         compiled_sections.sort(key=EpubHtml.get_name)
         self.compiled_sections = compiled_sections
 
+    def set_threads_date_range(
+        self,
+        start_date: datetime | str | None,
+        end_date: datetime | str | None,
+    ):
+        # if a lone thread is empty we'll just output the nothing normally
+        self.set_start_date(start_date)
+        self.set_end_date(end_date)
 
 def last_modified(book: EpubBook) -> datetime:
     for (content, attrs) in book.get_metadata("OPF", "meta"):
@@ -146,6 +182,16 @@ class Section:
         for thread in self.threads:
             thread.load_compiled_sections_from_old_book(old_book)
 
+    def set_threads_date_range(
+        self,
+        start_date: datetime | str | None,
+        end_date: datetime | str | None,
+    ):
+        for thread in self.threads:
+            thread.set_start_date(start_date)
+            thread.set_end_date(end_date)
+        self.threads = [thread for thread in self.threads if not thread.is_empty()]
+
 
 class Continuity:
     def __init__(
@@ -172,3 +218,17 @@ class Continuity:
     def load_compiled_sections_from_old_book(self, old_book: EpubBook):
         for thread in self.threads:
             thread.load_compiled_sections_from_old_book(old_book)
+
+    def set_threads_date_range(
+        self,
+        start_date: datetime | str | None,
+        end_date: datetime | str | None
+    ):
+        for section in self.sections:
+            section.set_threads_date_range(start_date, end_date)
+        if self.sectionless_threads is not None:
+            self.sectionless_threads.set_threads_date_range(start_date, end_date)
+        self.sections = [section for section in self.sections if section.threads]
+        if self.sectionless_threads is not None and not self.sectionless_threads.threads:
+            self.sectionless_threads = None
+        self.threads = [thread for thread in self.threads if not thread.is_empty()]

--- a/glowfic_dl/book_structure.py
+++ b/glowfic_dl/book_structure.py
@@ -22,6 +22,7 @@ output_template = """
 </html>
 """.lstrip()
 
+
 #################
 ##   Classes   ##
 #################
@@ -190,6 +191,10 @@ class Section:
         threads = [Thread(post_json) for post_json in post_jsons]
         return cls(id=id, title=name, threads=threads)
 
+    @property
+    def is_empty(self):
+        return not bool(self.threads)
+
     def add_title_page(self, title_page: EpubHtml):
         self.title_page = title_page
 
@@ -232,16 +237,20 @@ class Continuity:
         if sectionless_threads is not None:
             self.threads += sectionless_threads.threads
 
+    @property
+    def is_empty(self):
+        return not bool(self.threads)
+
     def add_title_page(self, title_page: HtmlSection):
         self.title_page = title_page
 
     def remove_empty_threads(self):
         for section in self.sections:
             section.remove_empty_threads()
-        self.sections = [section for section in self.sections if section.threads]
+        self.sections = [section for section in self.sections if not section.is_empty]
         if self.sectionless_threads is not None:
             self.sectionless_threads.remove_empty_threads()
-            if not self.sectionless_threads.threads:
+            if self.sectionless_threads.is_empty:
                 self.sectionless_threads = None
         self.threads = list(chain(*[section.threads for section in self.sections]))
 

--- a/glowfic_dl/helpers.py
+++ b/glowfic_dl/helpers.py
@@ -23,7 +23,6 @@ FILENAME_BANNED_CHAR_RANGES = (
     (ord("\U00100000"), ord("\U0010ffff")),  # Supplementary Private Use Area-B
 )
 
-
 ###################
 ##   Functions   ##
 ###################

--- a/glowfic_dl/helpers.py
+++ b/glowfic_dl/helpers.py
@@ -23,6 +23,7 @@ FILENAME_BANNED_CHAR_RANGES = (
     (ord("\U00100000"), ord("\U0010ffff")),  # Supplementary Private Use Area-B
 )
 
+
 ###################
 ##   Functions   ##
 ###################

--- a/glowfic_dl/main.py
+++ b/glowfic_dl/main.py
@@ -78,8 +78,6 @@ async def main():
         )
 
 
-# TODO: Probably want to add a step where we fetch the barebones metadata (so we can check the last update).
-# Maybe want to make a new type for that metadata.
 async def download_ebook(
     url: str,
     split: str,

--- a/glowfic_dl/main.py
+++ b/glowfic_dl/main.py
@@ -115,9 +115,8 @@ async def download_ebook(
         image_map.populate_from_threads(book_structure.threads)
         await downloader.download_images(image_map)
     render_threads(book_structure.threads, image_map, split)
-    book_structure.remove_empty_threads()
-    compile_threads(book_structure.threads)
 
+    book_structure.remove_empty_threads()
     if book_structure.is_empty:
         match book_structure:
             case Thread():
@@ -129,6 +128,8 @@ async def download_ebook(
         templ = 'Error: the {} "{}" (id {}) has no replies posted in the requested time period.'
         print(templ.format(book_type, book_structure.title, book_structure.id))
         return
+
+    compile_threads(book_structure.threads)
 
     book = assemble_book(book_structure, image_map)
 

--- a/glowfic_dl/main.py
+++ b/glowfic_dl/main.py
@@ -115,6 +115,7 @@ async def download_ebook(
         image_map.populate_from_threads(book_structure.threads)
         await downloader.download_images(image_map)
     render_threads(book_structure.threads, image_map, split)
+    book_structure.remove_empty_threads()
     compile_threads(book_structure.threads)
 
     book = assemble_book(book_structure, image_map)

--- a/glowfic_dl/main.py
+++ b/glowfic_dl/main.py
@@ -1,4 +1,6 @@
 import argparse
+from typing import Optional
+from datetime import datetime
 
 from ebooklib import epub
 
@@ -48,15 +50,19 @@ def get_args() -> argparse.Namespace:
     )
     parser.add_argument(
         '--start-date',
-        help='downloads only replies posted from this date. Format is ISO 8601, e.g. 2026-05-31 or 2026-05-31T14:30',
+        help='downloads only replies posted from this date. Format is ISO 8601, e.g. 2026-05-31 or 2026-05-31T14:30, interpreted as local time',
     )
     parser.add_argument(
         '--end-date',
-        help='downloads only replies posted up to this date. Format is ISO 8601, e.g. 2026-05-31 or 2026-05-31T14:30',
+        help='downloads only replies posted up to this date. Format is ISO 8601, e.g. 2026-05-31 or 2026-05-31T14:30, interpreted as local time',
     )
 
-    return parser.parse_args()
-
+    args =  parser.parse_args()
+    if args.start_date is not None:
+        args.start_date = datetime.fromisoformat(args.start_date).astimezone()
+    if args.end_date is not None:
+        args.end_date = datetime.fromisoformat(args.end_date).astimezone()
+    return args
 
 async def main():
     args = get_args()
@@ -75,8 +81,8 @@ async def download_ebook(
     url: str,
     split: str,
     filename_mode: str,
-    start_date: Optional[str] = None,
-    end_date: Optional[str] = None,
+    start_date: Optional[datetime] = None,
+    end_date: Optional[datetime] = None,
 ) -> str:
     async with Downloader() as downloader:
         book_structure = await downloader.get_book_structure(url)

--- a/glowfic_dl/main.py
+++ b/glowfic_dl/main.py
@@ -46,20 +46,42 @@ def get_args() -> argparse.Namespace:
         default="if_large",
         help="how often (if at all) to split the output book's internal representations of threads into multiple files. 'none' means no splits occur except at thread boundaries; 'if_large' splits threads over 200kB in size after every 200kB; 'every_post' splits after each post irrespective of size. Default: if_large",
     )
+    parser.add_argument(
+        '--start-date',
+        help='downloads only replies posted from this date. Format is ISO 8601, e.g. 2026-05-31 or 2026-05-31T14:30',
+    )
+    parser.add_argument(
+        '--end-date',
+        help='downloads only replies posted up to this date. Format is ISO 8601, e.g. 2026-05-31 or 2026-05-31T14:30',
+    )
 
     return parser.parse_args()
 
 
 async def main():
     args = get_args()
-    await download_ebook(args.url, args.split, "title")
+    await download_ebook(
+        args.url,
+        args.split,
+        "title",
+        args.start_date,
+        args.end_date,
+    )
 
 
 # TODO: Probably want to add a step where we fetch the barebones metadata (so we can check the last update).
 # Maybe want to make a new type for that metadata.
-async def download_ebook(url: str, split: str, filename_mode: str) -> str:
+async def download_ebook(
+    url: str,
+    split: str,
+    filename_mode: str,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+) -> str:
     async with Downloader() as downloader:
         book_structure = await downloader.get_book_structure(url)
+        book_structure.set_threads_date_range(start_date, end_date)
+
         match book_structure:
             case Thread():
                 print("Found 1 thread")

--- a/glowfic_dl/main.py
+++ b/glowfic_dl/main.py
@@ -83,7 +83,7 @@ async def download_ebook(
     filename_mode: str,
     start_date: Optional[datetime] = None,
     end_date: Optional[datetime] = None,
-) -> str:
+) -> Optional[str]:
     async with Downloader() as downloader:
         book_structure = await downloader.get_book_structure(url)
         book_structure.set_threads_date_range(start_date, end_date)
@@ -117,6 +117,18 @@ async def download_ebook(
     render_threads(book_structure.threads, image_map, split)
     book_structure.remove_empty_threads()
     compile_threads(book_structure.threads)
+
+    if book_structure.is_empty:
+        match book_structure:
+            case Thread():
+                book_type = 'thread'
+            case Section():
+                book_type = 'board section'
+            case Continuity():
+                book_type = 'continuity'
+        templ = 'Error: the {} "{}" (id {}) has no replies posted in the requested time period.'
+        print(templ.format(book_type, book_structure.title, book_structure.id))
+        return
 
     book = assemble_book(book_structure, image_map)
 

--- a/glowfic_dl/main.py
+++ b/glowfic_dl/main.py
@@ -64,6 +64,7 @@ def get_args() -> argparse.Namespace:
         args.end_date = datetime.fromisoformat(args.end_date).astimezone()
     return args
 
+
 async def main():
     args = get_args()
     await download_ebook(

--- a/glowfic_dl/main.py
+++ b/glowfic_dl/main.py
@@ -67,13 +67,15 @@ def get_args() -> argparse.Namespace:
 
 async def main():
     args = get_args()
-    await download_ebook(
-        args.url,
-        args.split,
-        "title",
-        args.start_date,
-        args.end_date,
-    )
+    async with Downloader() as downloader:
+        await download_ebook(
+            args.url,
+            args.split,
+            "title",
+            downloader,
+            args.start_date,
+            args.end_date,
+        )
 
 
 # TODO: Probably want to add a step where we fetch the barebones metadata (so we can check the last update).
@@ -82,39 +84,39 @@ async def download_ebook(
     url: str,
     split: str,
     filename_mode: str,
+    downloader: Downloader,
     start_date: Optional[datetime] = None,
     end_date: Optional[datetime] = None,
 ) -> Optional[str]:
-    async with Downloader() as downloader:
-        book_structure = await downloader.get_book_structure(url)
-        book_structure.set_threads_date_range(start_date, end_date)
+    book_structure = await downloader.get_book_structure(url)
+    book_structure.set_threads_date_range(start_date, end_date)
+    
+    match book_structure:
+        case Thread():
+            print("Found 1 thread")
+        case Section():
+            print("Found %i threads" % len(book_structure.threads))
+        case Continuity():
+            print(
+                "Found %i sections and %i threads"
+                % (len(book_structure.sections), len(book_structure.threads))
+            )
+            
+    out_path = gen_ebook_path(filename_mode, book_structure)
+    try:
+        old_book = epub.read_epub(out_path)
+    except:
+        old_book = None
+    image_map = ImageMap()
+    if old_book:
+        image_map.populate_from_book(old_book)
+        book_structure.load_compiled_sections_from_old_book(old_book)
 
-        match book_structure:
-            case Thread():
-                print("Found 1 thread")
-            case Section():
-                print("Found %i threads" % len(book_structure.threads))
-            case Continuity():
-                print(
-                    "Found %i sections and %i threads"
-                    % (len(book_structure.sections), len(book_structure.threads))
-                )
-
-        out_path = gen_ebook_path(filename_mode, book_structure)
-        try:
-            old_book = epub.read_epub(out_path)
-        except:
-            old_book = None
-        image_map = ImageMap()
-        if old_book:
-            image_map.populate_from_book(old_book)
-            book_structure.load_compiled_sections_from_old_book(old_book)
-
-        await downloader.download_threads(
-            book_structure.threads,
-        )
-        image_map.populate_from_threads(book_structure.threads)
-        await downloader.download_images(image_map)
+    await downloader.download_threads(
+        book_structure.threads,
+    )
+    image_map.populate_from_threads(book_structure.threads)
+    await downloader.download_images(image_map)
     render_threads(book_structure.threads, image_map, split)
 
     book_structure.remove_empty_threads()

--- a/glowfic_dl/render.py
+++ b/glowfic_dl/render.py
@@ -338,6 +338,18 @@ def get_posted_time(post: Tag) -> datetime:
     return posted_time
 
 
+def get_updated_time(post: Tag) -> Optional[datetime]:
+    span = post.find('span', class_='post-updated')
+    if span is None:
+        return None
+    time_tag = span.find("time")
+    assert time_tag is not None
+    datetime_str = get_attr(time_tag, "datetime")
+    updated_time = datetime.fromisoformat(datetime_str.rstrip('Z'))
+    updated_time = updated_time.replace(tzinfo=timezone.utc)
+    return updated_time
+
+
 def filter_posts_by_date(
     posts: Iterable[Tag],
     start_date: Optional[datetime],
@@ -346,6 +358,17 @@ def filter_posts_by_date(
     posts = list(posts)
     if start_date is not None:
         i = bisect.bisect_left(posts, start_date, key=get_posted_time)
+        # Includes tags at the start that were edited but not posted
+        # in the range we want
+        while True:
+            if i <= 0:
+                break  # no tags before
+            updated_time = get_updated_time(posts[i-1])
+            if updated_time is None:
+                break  # previous tag wasn't edited
+            if updated_time < start_date:
+                break  # edit was before minimum date
+            i -= 1
         posts = posts[i:]
     if end_date is not None:
         i = bisect.bisect_right(posts, end_date, key=get_posted_time)
@@ -370,6 +393,8 @@ def render_threads(threads: list[Thread], image_map: ImageMap, split: str):
 
         posts = chain([first_post], replies)
         posts = filter_posts_by_date(posts, thread.start_date, thread.end_date)
+        if not posts:
+            thread.mark_as_empty()
         thread.add_rendered_sections(
             list(render_posts(posts, image_map, thread.authors, thread.title, split))
         )

--- a/glowfic_dl/render.py
+++ b/glowfic_dl/render.py
@@ -294,7 +294,6 @@ def render_posts(
     title: str,
     split: str,
 ) -> Iterable[HtmlSection]:
-
     rendered_posts = [render_post(post, image_map) for post in posts]
 
     # Thread title page
@@ -390,7 +389,6 @@ def render_threads(threads: list[Thread], image_map: ImageMap, split: str):
         replies = replies_container.find_all(
             "div", class_="post-container", recursive=False
         )
-
         posts = chain([first_post], replies)
         posts = filter_posts_by_date(posts, thread.start_date, thread.end_date)
         if not posts:

--- a/glowfic_dl/render.py
+++ b/glowfic_dl/render.py
@@ -6,6 +6,8 @@ import ebooklib
 from typing_extensions import Self
 from urllib.parse import urlparse
 from hashlib import sha256
+from datetime import datetime, timezone
+import bisect
 
 from dataclasses import dataclass
 from bs4 import BeautifulSoup
@@ -199,6 +201,7 @@ class ImageMap:
             else:
                 assert thread.soup is not None
                 posts = thread.soup.find_all("div", class_="post-container")
+                posts = filter_posts_by_date(posts, thread.start_date, thread.end_date)
                 self.populate_from_posts(posts)
 
     def populate_from_posts(self, posts: ResultSet):
@@ -291,6 +294,7 @@ def render_posts(
     title: str,
     split: str,
 ) -> Iterable[HtmlSection]:
+
     rendered_posts = [render_post(post, image_map) for post in posts]
 
     # Thread title page
@@ -325,6 +329,30 @@ def render_posts(
         yield current_section
 
 
+def get_posted_time(post: Tag) -> datetime:
+    time_tag = post.find("time")
+    assert time_tag is not None
+    datetime_str = get_attr(time_tag, "datetime")
+    posted_time = datetime.fromisoformat(datetime_str.rstrip('Z'))
+    posted_time = posted_time.replace(tzinfo=timezone.utc)
+    return posted_time
+
+
+def filter_posts_by_date(
+    posts: Iterable[Tag],
+    start_date: Optional[datetime],
+    end_date: Optional[datetime],
+) -> list[Tag]:
+    posts = list(posts)
+    if start_date is not None:
+        i = bisect.bisect_left(posts, start_date, key=get_posted_time)
+        posts = posts[i:]
+    if end_date is not None:
+        i = bisect.bisect_right(posts, end_date, key=get_posted_time)
+        posts = posts[:i]
+    return posts
+
+
 def render_threads(threads: list[Thread], image_map: ImageMap, split: str):
     for thread in threads:
         if thread.compiled_sections is not None:
@@ -339,7 +367,9 @@ def render_threads(threads: list[Thread], image_map: ImageMap, split: str):
         replies = replies_container.find_all(
             "div", class_="post-container", recursive=False
         )
+
         posts = chain([first_post], replies)
+        posts = filter_posts_by_date(posts, thread.start_date, thread.end_date)
         thread.add_rendered_sections(
             list(render_posts(posts, image_map, thread.authors, thread.title, split))
         )


### PR DESCRIPTION
Added the ability to select replies by date range! Thread objects now only render the tags that were posted between their `start_date` and `end_date` attributes, if those are set. Unfortunately the entire thread still has to be downloaded, unless there were *no* tags in the given range in which case nothing is downloaded.
You can set these attributes (for a downloaded thread or all threads in a continuity/section) by using the `--start-date` and `--end-date` command line options.
If you try to re-download the same book, the program will only try to reuse stored threads if they have the same start date and end date (or if they aren't set for both of them).
